### PR TITLE
Add zstd compression support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tracing-instrument = []
 chrono = { version = "0.4.38", features = ["serde"] }
 reqwest = { version = "0.12.12", default-features = false, features = [
     "json",
+    "zstd",
     "rustls-tls-native-roots",
 ] }
 serde = { version = "1.0.217", features = ["derive", "rc"] }
@@ -34,6 +35,7 @@ target-lexicon = "0.13.1"
 is_ci = "1.2.0"
 sys-locale = "0.3.2"
 iana-time-zone = "0.1.61"
+async-compression = { version = "0.4.18", features = ["zstd", "tokio"] }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/src/checkin.rs
+++ b/src/checkin.rs
@@ -8,7 +8,14 @@ pub(crate) type CoherentFeatureFlags = HashMap<String, Arc<Feature<serde_json::V
 
 #[derive(Clone, Debug, Deserialize, Default)]
 pub struct Checkin {
+    #[serde(default)]
+    pub(crate) server_options: ServerOptions,
     pub(crate) options: CoherentFeatureFlags,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub(crate) struct ServerOptions {
+    pub(crate) compression_algorithms: crate::compression_set::CompressionSet,
 }
 
 impl Checkin {
@@ -44,7 +51,6 @@ pub struct Feature<T: serde::de::DeserializeOwned> {
 
 #[cfg(test)]
 mod test {
-
     #[test]
     fn test_parse() {
         let json = r#"

--- a/src/compression_set.rs
+++ b/src/compression_set.rs
@@ -4,14 +4,13 @@ use tokio::io::AsyncWriteExt;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct CompressionSet {
     zstd: bool,
-    identity: bool,
 }
 
 impl CompressionSet {
     pub(crate) fn delete(&mut self, algo: &CompressionAlgorithm) {
         match algo {
             CompressionAlgorithm::Identity => {
-                self.identity = false;
+                // noop
             }
             CompressionAlgorithm::Zstd => {
                 self.zstd = false;
@@ -24,9 +23,8 @@ impl CompressionSet {
         if self.zstd {
             algos.push(CompressionAlgorithm::Zstd);
         }
-        if self.identity {
-            algos.push(CompressionAlgorithm::Identity);
-        }
+
+        algos.push(CompressionAlgorithm::Identity);
 
         algos.into_iter()
     }
@@ -34,10 +32,7 @@ impl CompressionSet {
 
 impl std::default::Default for CompressionSet {
     fn default() -> Self {
-        Self {
-            zstd: true,
-            identity: true,
-        }
+        Self { zstd: true }
     }
 }
 
@@ -60,16 +55,10 @@ impl<'de> Deserialize<'de> for CompressionSet {
             .collect();
 
         if algos.is_empty() {
-            return Ok(CompressionSet {
-                zstd: false,
-                identity: true,
-            });
+            return Ok(CompressionSet { zstd: false });
         }
 
-        let mut set = CompressionSet {
-            zstd: false,
-            identity: false,
-        };
+        let mut set = CompressionSet { zstd: false };
 
         for algo in algos.into_iter() {
             match algo {
@@ -77,7 +66,7 @@ impl<'de> Deserialize<'de> for CompressionSet {
                     set.zstd = true;
                 }
                 CompressionAlgorithm::Identity => {
-                    set.identity = true;
+                    // noop
                 }
             }
         }
@@ -129,10 +118,7 @@ mod test {
 
         assert_eq!(
             serde_json::from_str::<CompressionSet>(json).unwrap(),
-            CompressionSet {
-                zstd: false,
-                identity: true
-            }
+            CompressionSet { zstd: false }
         );
     }
 
@@ -147,10 +133,7 @@ mod test {
 
         assert_eq!(
             serde_json::from_str::<CompressionSet>(json).unwrap(),
-            CompressionSet {
-                zstd: true,
-                identity: true
-            }
+            CompressionSet { zstd: true }
         );
     }
 
@@ -164,10 +147,7 @@ mod test {
 
         assert_eq!(
             serde_json::from_str::<CompressionSet>(json).unwrap(),
-            CompressionSet {
-                zstd: true,
-                identity: false
-            }
+            CompressionSet { zstd: true }
         );
     }
 
@@ -182,10 +162,7 @@ mod test {
 
         assert_eq!(
             serde_json::from_str::<CompressionSet>(json).unwrap(),
-            CompressionSet {
-                zstd: true,
-                identity: false
-            }
+            CompressionSet { zstd: true }
         );
     }
 }

--- a/src/compression_set.rs
+++ b/src/compression_set.rs
@@ -1,0 +1,191 @@
+use serde::Deserialize;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CompressionSet {
+    zstd: bool,
+    identity: bool,
+}
+
+impl CompressionSet {
+    pub(crate) fn delete(&mut self, algo: &CompressionAlgorithm) {
+        match algo {
+            CompressionAlgorithm::Identity => {
+                self.identity = false;
+            }
+            CompressionAlgorithm::Zstd => {
+                self.zstd = false;
+            }
+        }
+    }
+
+    pub(crate) fn into_iter(self) -> std::vec::IntoIter<CompressionAlgorithm> {
+        let mut algos = Vec::with_capacity(2);
+        if self.zstd {
+            algos.push(CompressionAlgorithm::Zstd);
+        }
+        if self.identity {
+            algos.push(CompressionAlgorithm::Identity);
+        }
+
+        algos.into_iter()
+    }
+}
+
+impl std::default::Default for CompressionSet {
+    fn default() -> Self {
+        Self {
+            zstd: true,
+            identity: true,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CompressionSet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let algos: Vec<_> = Vec::<serde_json::Value>::deserialize(deserializer)?
+            .into_iter()
+            .filter_map(
+                |v| match serde_json::from_value::<CompressionAlgorithm>(v) {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        tracing::trace!(%e, "Unsupported compression algorithm");
+                        None
+                    }
+                },
+            )
+            .collect();
+
+        if algos.is_empty() {
+            return Ok(CompressionSet {
+                zstd: false,
+                identity: true,
+            });
+        }
+
+        let mut set = CompressionSet {
+            zstd: false,
+            identity: false,
+        };
+
+        for algo in algos.into_iter() {
+            match algo {
+                CompressionAlgorithm::Zstd => {
+                    set.zstd = true;
+                }
+                CompressionAlgorithm::Identity => {
+                    set.identity = true;
+                }
+            }
+        }
+
+        Ok(set)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum CompressionAlgorithm {
+    Identity,
+    Zstd,
+}
+
+impl CompressionAlgorithm {
+    pub(crate) fn content_encoding(&self) -> Option<String> {
+        match self {
+            CompressionAlgorithm::Identity => None,
+            CompressionAlgorithm::Zstd => Some("zstd".to_string()),
+        }
+    }
+
+    pub(crate) async fn compress(&self, r: &[u8]) -> Result<Vec<u8>, std::io::Error> {
+        match self {
+            CompressionAlgorithm::Identity => Ok(r.into()),
+            CompressionAlgorithm::Zstd => {
+                let mut output: Vec<u8> = vec![];
+                let mut encoder = async_compression::tokio::write::ZstdEncoder::new(&mut output);
+                encoder.write_all(r).await?;
+                encoder.shutdown().await?;
+
+                Ok(output)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::CompressionSet;
+
+    #[test]
+    fn test_parse_compression_empty_defaults_to_identity() {
+        let json = r#"
+        [
+        ]
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<CompressionSet>(json).unwrap(),
+            CompressionSet {
+                zstd: false,
+                identity: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_few() {
+        let json = r#"
+        [
+          "zstd",
+          "identity"
+        ]
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<CompressionSet>(json).unwrap(),
+            CompressionSet {
+                zstd: true,
+                identity: true
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_zstd_not_identity() {
+        let json = r#"
+        [
+          "zstd"
+        ]
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<CompressionSet>(json).unwrap(),
+            CompressionSet {
+                zstd: true,
+                identity: false
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_compression_zstd_with_bogus() {
+        let json = r#"
+        [
+          "zstd",
+          "abc123"
+        ]
+        "#;
+
+        assert_eq!(
+            serde_json::from_str::<CompressionSet>(json).unwrap(),
+            CompressionSet {
+                zstd: true,
+                identity: false
+            }
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 mod builder;
 pub mod checkin;
 mod collator;
+mod compression_set;
 mod configuration_proxy;
 mod ds_correlation;
 mod identity;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -109,6 +109,7 @@ impl Transport for Transports {
         match self {
             Self::None => Ok(crate::checkin::Checkin {
                 options: std::collections::HashMap::new(),
+                ..Default::default()
             }),
             Self::File(t) => Ok(t.checkin(session_properties).await?),
             Self::Http(t) => Ok(t.checkin(session_properties).await?),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -19,7 +19,14 @@ pub struct Worker {
 impl Worker {
     #[cfg_attr(
         feature = "tracing-instrument",
-        tracing::instrument(skip(system_snapshotter, transport))
+        tracing::instrument(skip(
+            distinct_id,
+            device_id,
+            facts,
+            groups,
+            system_snapshotter,
+            transport
+        ))
     )]
     pub(crate) async fn new<F: SystemSnapshotter, T: Transport + Sync + 'static>(
         distinct_id: Option<DistinctId>,


### PR DESCRIPTION
This adds the ability to send and receive compressed data from the IDS backend. It does this by assuming the backend supports zstd and making the initial connection. If it gets a 415 back, it falls back to "identity" which means no compression.

It will also fetch a list of supported algorithms in the check-in phase. All supported algorithms will be attempted, in an order of preference (right now: zstd -> identity.)
