### PR TITLE
Teach ids-client about storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "detsys-ids-client"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for install.determinate.systems."

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ You can see our privacy policy at https://determinate.systems/policies/privacy/.
 ```mermaid
 flowchart TD
     Recorder --> Collator
+    Storage --> Collator
     ConfigurationProxy --> Recorder
 
     subgraph Worker
@@ -26,6 +27,7 @@ flowchart TD
 Components:
 
 - **Recorder** is the user-interface and cheap to clone, doing all the work over channels.
+- **Storage** models persistent storage between executions, which may be a no-op in-memory implementation.
 - **ConfigurationProxy** reads configuration and feature properties from the **Transport**.
 - **Collator** fetches a recent **SystemSnapshot** from the **SystemSnapshotter** and agggregates the total sum of facts and event data to enrich the basic event data from the **Recorder**. Those events are then sent to the **Submitter**.
 - **SystemSnapshotter** produces a fresh **SystemSnapshot** of the host. This may include properties that change frequently, like thermal state, so a SystemSnapshot must not be reused.
@@ -54,11 +56,13 @@ Components:
 The correlation data is mixed in to the event data by the Collator, and:
 
 - `$session_id` is preferred over generating a new one.
-- `$anon_distinct_id` is preferred over generating a new one, but is unused if the client builder explicitly passes an anonymous distinct ID.
+- `$anon_distinct_id` is preferred over generating a new one.
 - `distinct_id` is used if the user of the library doesn't explicitly pass a distinct ID.
 - `$device_id` is used instead of generating a new one if the user doesn't explicitly pass a device ID.
 - `$groups` is merged in to the user-provided groups.
 - Any additional property is appended to the user-provided facts.
+
+Note that `$anon_distinct_id`, `distinct_id`, and `$device_id` are disregarded if the Storage implementation has stored properties available.
 
 ### To-do
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Components:
 The correlation data is mixed in to the event data by the Collator, and:
 
 - `$session_id` is preferred over generating a new one.
-- `$anon_distinct_id` is preferred over generating a new one.
+- `$anon_distinct_id` is preferred over generating a new one, but is unused if the client builder explicitly passes an anonymous distinct ID.
 - `distinct_id` is used if the user of the library doesn't explicitly pass a distinct ID.
 - `$device_id` is used instead of generating a new one if the user doesn't explicitly pass a device ID.
 - `$groups` is merged in to the user-provided groups.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use reqwest::Certificate;
 use url::Url;
 
+use crate::identity::AnonymousDistinctId;
 use crate::transport::TransportsError;
 use crate::{system_snapshot::SystemSnapshotter, DeviceId, DistinctId, Map};
 use crate::{Recorder, Worker};
@@ -11,6 +12,7 @@ use crate::{Recorder, Worker};
 pub struct Builder {
     device_id: Option<DeviceId>,
     distinct_id: Option<DistinctId>,
+    anonymous_distinct_id: Option<AnonymousDistinctId>,
     enable_reporting: bool,
     endpoint: Option<String>,
     facts: Option<Map>,
@@ -25,6 +27,7 @@ impl Builder {
         Builder {
             device_id: None,
             distinct_id: None,
+            anonymous_distinct_id: None,
             enable_reporting: true,
             endpoint: None,
             facts: None,
@@ -33,6 +36,14 @@ impl Builder {
             certificate: None,
             timeout: None,
         }
+    }
+
+    pub fn set_anonymous_distinct_id(
+        mut self,
+        anonymous_distinct_id: Option<AnonymousDistinctId>,
+    ) -> Self {
+        self.anonymous_distinct_id = anonymous_distinct_id;
+        self
     }
 
     pub fn set_distinct_id(mut self, distinct_id: Option<DistinctId>) -> Self {
@@ -159,6 +170,7 @@ impl Builder {
         snapshotter: S,
     ) -> (Recorder, Worker) {
         Worker::new(
+            self.anonymous_distinct_id.take(),
             self.distinct_id.take(),
             self.device_id.take(),
             self.facts.take(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -161,7 +161,7 @@ impl Builder {
     }
 
     #[tracing::instrument(skip(self, snapshotter, storage))]
-    pub async fn build_or_default_with_snapshotter<S: SystemSnapshotter, P: Storage>(
+    pub async fn build_or_default_with<S: SystemSnapshotter, P: Storage>(
         mut self,
         snapshotter: S,
         storage: P,

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -112,12 +112,16 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
                 .session_id
                 .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
             anon_distinct_id: anonymous_distinct_id
-                .or(stored_ident
-                    .as_ref()
-                    .map(|props| props.anonymous_distinct_id.clone()))
-                .or(correlation_data
-                    .anon_distinct_id
-                    .map(AnonymousDistinctId::from))
+                .or_else(|| {
+                    stored_ident
+                        .as_ref()
+                        .map(|props| props.anonymous_distinct_id.clone())
+                })
+                .or_else(|| {
+                    correlation_data
+                        .anon_distinct_id
+                        .map(AnonymousDistinctId::from)
+                })
                 .unwrap_or_else(|| AnonymousDistinctId::from(uuid::Uuid::now_v7().to_string())),
             distinct_id: distinct_id
                 .or(stored_ident

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -284,6 +284,18 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
             self.anon_distinct_id = AnonymousDistinctId::from(uuid::Uuid::now_v7().to_string());
         }
 
+        if let Err(e) = self
+            .storage
+            .store(&crate::storage::StoredProperties {
+                distinct_id: self.distinct_id.clone(),
+                anonymous_distinct_id: self.anon_distinct_id.clone(),
+                device_id: self.device_id.clone(),
+            })
+            .await
+        {
+            tracing::debug!(%e, "Storage error");
+        }
+
         let snapshot = self.system_snapshotter.snapshot();
 
         self.outgoing

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -288,7 +288,7 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
 
         if let Err(e) = self
             .storage
-            .store(&crate::storage::StoredProperties {
+            .store(crate::storage::StoredProperties {
                 distinct_id: self.distinct_id.clone(),
                 anonymous_distinct_id: self.anon_distinct_id.clone(),
                 device_id: self.device_id.clone(),
@@ -339,7 +339,7 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
 
         if let Err(e) = self
             .storage
-            .store(&crate::storage::StoredProperties {
+            .store(crate::storage::StoredProperties {
                 distinct_id: self.distinct_id.clone(),
                 anonymous_distinct_id: self.anon_distinct_id.clone(),
                 device_id: self.device_id.clone(),

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::oneshot::Sender as OneshotSender;
+use tokio::sync::Mutex;
 use tracing::Instrument;
 
 use crate::ds_correlation::Correlation;
@@ -72,7 +73,7 @@ pub(crate) enum SnapshotError {
 
 pub(crate) struct Collator<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage>
 {
-    system_snapshotter: F,
+    system_snapshotter: Mutex<F>,
     storage: P,
     incoming: Receiver<RawSignal>,
     outgoing: Sender<CollatedSignal>,
@@ -104,7 +105,7 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
         let stored_ident = storage.load().await.ok().flatten();
 
         Self {
-            system_snapshotter,
+            system_snapshotter: Mutex::new(system_snapshotter),
             storage,
             incoming,
             outgoing,
@@ -266,7 +267,7 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
         event_name: String,
         properties: Option<Map>,
     ) -> Result<(), SnapshotError> {
-        let snapshot = self.system_snapshotter.snapshot();
+        let snapshot = self.system_snapshotter.lock().await.snapshot();
         self.outgoing
             .send(CollatedSignal::Event(
                 self.msg_to_event(snapshot, event_name, properties),
@@ -298,7 +299,7 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
             tracing::debug!(%e, "Storage error");
         }
 
-        let snapshot = self.system_snapshotter.snapshot();
+        let snapshot = self.system_snapshotter.lock().await.snapshot();
 
         self.outgoing
             .send(CollatedSignal::Event(self.msg_to_event(
@@ -318,7 +319,7 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
 
         properties.insert("alias".to_string(), alias.into());
 
-        let snapshot = self.system_snapshotter.snapshot();
+        let snapshot = self.system_snapshotter.lock().await.snapshot();
 
         self.outgoing
             .send(CollatedSignal::Event(self.msg_to_event(

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -124,12 +124,14 @@ impl<F: crate::system_snapshot::SystemSnapshotter, P: crate::storage::Storage> C
                 })
                 .unwrap_or_else(|| AnonymousDistinctId::from(uuid::Uuid::now_v7().to_string())),
             distinct_id: distinct_id
-                .or(stored_ident
-                    .as_ref()
-                    .and_then(|props| props.distinct_id.clone()))
+                .or_else(|| {
+                    stored_ident
+                        .as_ref()
+                        .and_then(|props| props.distinct_id.clone())
+                })
                 .or(correlation_data.distinct_id),
             device_id: device_id
-                .or(stored_ident.map(|props| props.device_id))
+                .or_else(|| stored_ident.map(|props| props.device_id))
                 .or(correlation_data.device_id)
                 .unwrap_or_default(),
             facts,

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,4 +1,19 @@
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct AnonymousDistinctId(String);
+
+impl From<String> for AnonymousDistinctId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for AnonymousDistinctId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct DistinctId(String);
 
 impl From<String> for DistinctId {

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,6 +1,12 @@
 #[derive(serde::Deserialize, serde::Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct AnonymousDistinctId(String);
 
+impl AnonymousDistinctId {
+    pub fn new() -> AnonymousDistinctId {
+        AnonymousDistinctId(uuid::Uuid::now_v7().to_string())
+    }
+}
+
 impl From<String> for AnonymousDistinctId {
     fn from(value: String) -> Self {
         Self(value)

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -7,6 +7,12 @@ impl AnonymousDistinctId {
     }
 }
 
+impl Default for AnonymousDistinctId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<String> for AnonymousDistinctId {
     fn from(value: String) -> Self {
         Self(value)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod ds_correlation;
 mod identity;
 mod json_string;
 mod recorder;
+pub mod storage;
 mod submitter;
 pub mod system_snapshot;
 pub mod transport;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ pub mod transport;
 mod worker;
 
 pub use builder::Builder;
-pub use identity::{DeviceId, DistinctId};
+pub use identity::{AnonymousDistinctId, DeviceId, DistinctId};
 pub use recorder::Recorder;
 pub use worker::Worker;
 

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -1,0 +1,19 @@
+use tokio::sync::RwLock;
+
+#[derive(Default)]
+pub struct Generic {
+    state: RwLock<Option<super::StoredProperties>>,
+}
+
+impl super::Storage for Generic {
+    type Error = std::convert::Infallible;
+
+    async fn load(&self) -> Result<Option<super::StoredProperties>, Self::Error> {
+        Ok((*self.state.read().await).clone())
+    }
+
+    async fn store(&mut self, properties: &super::StoredProperties) -> Result<(), Self::Error> {
+        *self.state.write().await = Some(properties.clone());
+        Ok(())
+    }
+}

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -12,8 +12,8 @@ impl super::Storage for Generic {
         Ok((*self.state.read().await).clone())
     }
 
-    async fn store(&mut self, properties: &super::StoredProperties) -> Result<(), Self::Error> {
-        *self.state.write().await = Some(properties.clone());
+    async fn store(&mut self, properties: super::StoredProperties) -> Result<(), Self::Error> {
+        *self.state.write().await = Some(properties);
         Ok(())
     }
 }

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -1,19 +1,17 @@
-use tokio::sync::RwLock;
-
 #[derive(Default)]
 pub struct Generic {
-    state: RwLock<Option<super::StoredProperties>>,
+    state: Option<super::StoredProperties>,
 }
 
 impl super::Storage for Generic {
     type Error = std::convert::Infallible;
 
     async fn load(&self) -> Result<Option<super::StoredProperties>, Self::Error> {
-        Ok((*self.state.read().await).clone())
+        Ok(self.state.clone())
     }
 
     async fn store(&mut self, properties: super::StoredProperties) -> Result<(), Self::Error> {
-        *self.state.write().await = Some(properties);
+        self.state = Some(properties);
         Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,24 @@
+mod generic;
+pub use generic::Generic;
+
+use crate::identity::AnonymousDistinctId;
+use crate::{DeviceId, DistinctId};
+
+#[derive(Clone)]
+pub struct StoredProperties {
+    pub anonymous_distinct_id: AnonymousDistinctId,
+    pub distinct_id: Option<DistinctId>,
+    pub device_id: DeviceId,
+}
+
+pub trait Storage: Send + Sync + 'static {
+    type Error: std::fmt::Debug + std::fmt::Display;
+
+    fn load(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Option<StoredProperties>, Self::Error>> + Send;
+    fn store(
+        &mut self,
+        properties: &StoredProperties,
+    ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub use generic::Generic;
 use crate::identity::AnonymousDistinctId;
 use crate::{DeviceId, DistinctId};
 
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct StoredProperties {
     pub anonymous_distinct_id: AnonymousDistinctId,
     pub distinct_id: Option<DistinctId>,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -19,6 +19,6 @@ pub trait Storage: Send + Sync + 'static {
     ) -> impl std::future::Future<Output = Result<Option<StoredProperties>, Self::Error>> + Send;
     fn store(
         &mut self,
-        properties: &StoredProperties,
+        properties: StoredProperties,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,7 @@ pub use generic::Generic;
 use crate::identity::AnonymousDistinctId;
 use crate::{DeviceId, DistinctId};
 
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StoredProperties {
     pub anonymous_distinct_id: AnonymousDistinctId,
     pub distinct_id: Option<DistinctId>,

--- a/src/submitter.rs
+++ b/src/submitter.rs
@@ -69,6 +69,8 @@ impl<T: crate::transport::Transport> Submitter<T> {
             batch: &self.events,
         };
 
+        tracing::trace!(?batch, "Submitting batch");
+
         match self.transport.submit(batch).await {
             Ok(_) => {
                 tracing::trace!("submitted events");

--- a/src/system_snapshot/generic.rs
+++ b/src/system_snapshot/generic.rs
@@ -1,5 +1,3 @@
-use std::io::IsTerminal;
-
 use crate::system_snapshot::{SystemSnapshot, SystemSnapshotter};
 
 #[derive(Default)]
@@ -8,31 +6,6 @@ pub struct Generic {}
 impl SystemSnapshotter for Generic {
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
     fn snapshot(&self) -> SystemSnapshot {
-        let system = sysinfo::System::new_all();
-
-        let is_ci = is_ci::cached()
-            || std::env::var("DETSYS_IDS_IN_CI").unwrap_or_else(|_| "0".into()) == "1";
-
-        SystemSnapshot {
-            locale: sys_locale::get_locale(),
-            timezone: iana_time_zone::get_timezone().ok(),
-
-            host_name: sysinfo::System::host_name(),
-            operating_system: sysinfo::System::long_os_version(),
-            operating_system_version: sysinfo::System::os_version(),
-
-            target_triple: target_lexicon::HOST.to_string(),
-            stdin_is_terminal: std::io::stdin().is_terminal(),
-            is_ci,
-
-            processor_count: system.physical_core_count().map(
-                |count| count as u64, /* safety: `as` truncates on overflow */
-            ),
-            physical_memory_bytes: system.total_memory(),
-            boot_time: sysinfo::System::boot_time(),
-            process_name: std::env::args().next(),
-
-            extra_fields: None,
-        }
+        SystemSnapshot::default()
     }
 }

--- a/src/system_snapshot/generic.rs
+++ b/src/system_snapshot/generic.rs
@@ -5,7 +5,7 @@ pub struct Generic {}
 
 impl SystemSnapshotter for Generic {
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
-    fn snapshot(&mut self) -> SystemSnapshot {
+    fn snapshot(&self) -> SystemSnapshot {
         SystemSnapshot::default()
     }
 }

--- a/src/system_snapshot/generic.rs
+++ b/src/system_snapshot/generic.rs
@@ -5,7 +5,7 @@ pub struct Generic {}
 
 impl SystemSnapshotter for Generic {
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
-    fn snapshot(&self) -> SystemSnapshot {
+    fn snapshot(&mut self) -> SystemSnapshot {
         SystemSnapshot::default()
     }
 }

--- a/src/system_snapshot/mod.rs
+++ b/src/system_snapshot/mod.rs
@@ -78,6 +78,6 @@ impl Default for SystemSnapshot {
     }
 }
 
-pub trait SystemSnapshotter: Send + 'static {
-    fn snapshot(&mut self) -> SystemSnapshot;
+pub trait SystemSnapshotter: Send + Sync + 'static {
+    fn snapshot(&self) -> SystemSnapshot;
 }

--- a/src/system_snapshot/mod.rs
+++ b/src/system_snapshot/mod.rs
@@ -78,6 +78,6 @@ impl Default for SystemSnapshot {
     }
 }
 
-pub trait SystemSnapshotter: Send + Sync + 'static {
-    fn snapshot(&self) -> SystemSnapshot;
+pub trait SystemSnapshotter: Send + 'static {
+    fn snapshot(&mut self) -> SystemSnapshot;
 }

--- a/src/system_snapshot/mod.rs
+++ b/src/system_snapshot/mod.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use crate::Map;
 
 mod generic;
@@ -43,6 +45,37 @@ pub struct SystemSnapshot {
     /// Additional fields to be flattened into the snapshot data
     #[serde(flatten)]
     pub extra_fields: Option<Map>,
+}
+
+impl Default for SystemSnapshot {
+    fn default() -> Self {
+        let system = sysinfo::System::new_all();
+
+        let is_ci = is_ci::cached()
+            || std::env::var("DETSYS_IDS_IN_CI").unwrap_or_else(|_| "0".into()) == "1";
+
+        Self {
+            locale: sys_locale::get_locale(),
+            timezone: iana_time_zone::get_timezone().ok(),
+
+            host_name: sysinfo::System::host_name(),
+            operating_system: sysinfo::System::long_os_version(),
+            operating_system_version: sysinfo::System::os_version(),
+
+            target_triple: target_lexicon::HOST.to_string(),
+            stdin_is_terminal: std::io::stdin().is_terminal(),
+            is_ci,
+
+            processor_count: system.physical_core_count().map(
+                |count| count as u64, /* safety: `as` truncates on overflow */
+            ),
+            physical_memory_bytes: system.total_memory(),
+            boot_time: sysinfo::System::boot_time(),
+            process_name: std::env::args().next(),
+
+            extra_fields: None,
+        }
+    }
 }
 
 pub trait SystemSnapshotter: Send + Sync + 'static {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,6 +5,7 @@ use tracing::Instrument;
 use crate::collator::{Collator, SnapshotError};
 use crate::configuration_proxy::{ConfigurationProxy, ConfigurationProxyError};
 use crate::ds_correlation::Correlation;
+use crate::identity::AnonymousDistinctId;
 use crate::submitter::Submitter;
 use crate::system_snapshot::SystemSnapshotter;
 use crate::transport::Transport;
@@ -20,6 +21,7 @@ impl Worker {
     #[cfg_attr(
         feature = "tracing-instrument",
         tracing::instrument(skip(
+            anonymous_distinct_id,
             distinct_id,
             device_id,
             facts,
@@ -29,6 +31,7 @@ impl Worker {
         ))
     )]
     pub(crate) async fn new<F: SystemSnapshotter, T: Transport + Sync + 'static>(
+        anonymous_distinct_id: Option<AnonymousDistinctId>,
         distinct_id: Option<DistinctId>,
         device_id: Option<DeviceId>,
         facts: Option<Map>,
@@ -51,6 +54,7 @@ impl Worker {
             system_snapshotter,
             collator_rx,
             to_submitter,
+            anonymous_distinct_id,
             distinct_id,
             device_id,
             facts.unwrap_or_default(),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -32,6 +32,7 @@ impl Worker {
             transport
         ))
     )]
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new<F: SystemSnapshotter, P: Storage, T: Transport + Sync + 'static>(
         anonymous_distinct_id: Option<AnonymousDistinctId>,
         distinct_id: Option<DistinctId>,


### PR DESCRIPTION
For determinate-nixd, we need a place to store the idea of being identified between executions. This patch gives the Collator a Storage implementation that can be used to load and persist data. Note the default implementation is noop / in-memory, but it can be overridden at construction time.

This also downgrades the preference of the DETSYS_CORRELATION data, preferring data found in storage over that environment variable.

Finally, since storage is persistent, this adds a "reset" call on the recorder to clear out the storage.