### PR TITLE
Support an identity file to support feature flagging based off GitHub orgs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "detsys-ids-client"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "A client for install.determinate.systems."

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ The correlation data is mixed in to the event data by the Collator, and:
 
 Note that `$anon_distinct_id`, `distinct_id`, and `$device_id` are disregarded if the Storage implementation has stored properties available.
 
+### Files
+
+- `/var/lib/determinate/identity.json` -- Contains correlation data that is provided by an external tool.
+  This library only reads this file for aiding with feature flagging support.
+
 ### To-do
 
 - Rotate sessions after inactivity: https://github.com/PostHog/posthog-ios/blob/35d7b9306ae932da869a8c1fcadf2232494a5e71/PostHog/PostHogSessionManager.swift#L57-L69

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -46,13 +46,13 @@ struct EventProperties {
     groups: Map,
 
     #[serde(flatten)]
+    snapshot: crate::system_snapshot::SystemSnapshot,
+
+    #[serde(flatten)]
     facts: Map,
 
     #[serde(flatten)]
     featurefacts: FeatureFacts,
-
-    #[serde(flatten)]
-    snapshot: crate::system_snapshot::SystemSnapshot,
 
     #[serde(flatten)]
     properties: Option<Map>,


### PR DESCRIPTION
This is for determinate-nixd to be able to access the same correlation data that is provided by detsys-ts in GitHub Actions. The goal is to allow the daemon to correctly fetch feature flags for the organization / repository, so users can opt in and out of features like lazy trees during its rollout.