### PR TITLE
what if: neon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 Cargo.lock
 .direnv
+node_modules
+index.node
+package-lock.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "detsys-ids-client"
 version = "0.4.3"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "A client for install.determinate.systems."
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default = ["nodejs"]
 
 # See: https://github.com/tokio-rs/tracing/issues/3207
 tracing-instrument = []
-nodejs = ["neon"]
+nodejs = ["neon", "once_cell"]
 
 [lib]
 crate-type = ["lib", "cdylib"]
@@ -41,6 +41,7 @@ sys-locale = "0.3.2"
 iana-time-zone = "0.1.61"
 async-compression = { version = "0.4.18", features = ["zstd", "tokio"] }
 neon = { version = "1", features = [ "tokio" ], optional = true }
+once_cell = { version = "1.21.3", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,14 @@ version = "0.4.3"
 edition = "2024"
 license = "Apache-2.0"
 description = "A client for install.determinate.systems."
+exclude = ["index.node"]
 
 [features]
-default = []
+default = ["nodejs"]
 
 # See: https://github.com/tokio-rs/tracing/issues/3207
 tracing-instrument = []
+nodejs = ["neon"]
 
 [lib]
 crate-type = ["lib", "cdylib"]
@@ -38,6 +40,7 @@ is_ci = "1.2.0"
 sys-locale = "0.3.2"
 iana-time-zone = "0.1.61"
 async-compression = { version = "0.4.18", features = ["zstd", "tokio"] }
+neon = { version = "1", features = [ "tokio" ], optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ default = []
 # See: https://github.com/tokio-rs/tracing/issues/3207
 tracing-instrument = []
 
+[lib]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/flake.lock
+++ b/flake.lock
@@ -8,12 +8,12 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1735713283,
-        "narHash": "sha256-xC6X49L55xo7AV+pAYclOj5UNWtBo/xx5aB5IehJD0M=",
-        "rev": "bfba822a4220b0e2c4dc7f36a35e4c8450cd9a9c",
-        "revCount": 2125,
+        "lastModified": 1740810935,
+        "narHash": "sha256-6RzWfxENGlO73jQb3uQNgOvubUFwvveeIg+PZxhAu6s=",
+        "rev": "f44d7c3596ff028ad9f7fcc31d1941ed585f11b3",
+        "revCount": 2184,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2125%2Brev-bfba822a4220b0e2c4dc7f36a35e4c8450cd9a9c/019420f1-c64f-7176-bdf5-3f4f4fe2bac6/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/fenix/0.1.2184%2Brev-f44d7c3596ff028ad9f7fcc31d1941ed585f11b3/019550c8-7792-7766-8dd2-80fad5595f70/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -27,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736429655,
-        "narHash": "sha256-BwMekRuVlSB9C0QgwKMICiJ5EVbLGjfe4qyueyNQyGI=",
+        "lastModified": 1745925850,
+        "narHash": "sha256-cyAAMal0aPrlb1NgzMxZqeN1mAJ2pJseDhm2m6Um8T0=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "0621e47bd95542b8e1ce2ee2d65d6a1f887a13ce",
+        "rev": "38bc60bbc157ae266d4a0c96671c6c742ee17a5f",
         "type": "github"
       },
       "original": {
@@ -42,12 +42,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
-        "revCount": 745286,
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
+        "revCount": 823481,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.745286%2Brev-9d3ae807ebd2981d593cddd0080856873139aa40/0194b46f-1b01-753f-9c65-43dede8f3124/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.823481%2Brev-3016b4b15d13f3089db8a41ef937b13a9e33a8df/0197c395-ee09-7755-bdd6-ec3500ffc720/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -64,11 +64,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1735659655,
-        "narHash": "sha256-DQgwi3pwaasWWDfNtXIX0lW5KvxQ+qVhxO1J7l68Qcc=",
+        "lastModified": 1740737930,
+        "narHash": "sha256-2AW/FJQI/i6bbRB/8HR9l9SjxjuiukJpHdMPgwApPKA=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "085ad107943996c344633d58f26467b05f8e2ff0",
+        "rev": "fe8444616679f8e50ff9696f4750df1f10e7433d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
               check.check-editorconfig
               check.check-clippy
               libiconv
+              nodePackages.npm
             ];
           };
         });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "detsys-ids-client",
+  "version": "0.4.3",
+  "description": "A client for install.determinate.systems.",
+  "main": "index.node",
+  "scripts": {
+    "build": "cargo-cp-artifact -nc index.node -- cargo build --message-format=json-render-diagnostics",
+    "install": "npm run build",
+    "test": "cargo test"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "cargo-cp-artifact": "^0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DeterminateSystems/detsys-ids-client.git"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/DeterminateSystems/detsys-ids-client/issues"
+  },
+  "homepage": "https://github.com/DeterminateSystems/detsys-ids-client#readme"
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,7 +6,7 @@ use url::Url;
 use crate::identity::AnonymousDistinctId;
 use crate::storage::Storage;
 use crate::transport::TransportsError;
-use crate::{system_snapshot::SystemSnapshotter, DeviceId, DistinctId, Map};
+use crate::{DeviceId, DistinctId, Map, system_snapshot::SystemSnapshotter};
 use crate::{Recorder, Worker};
 
 #[derive(Default)]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ use crate::transport::TransportsError;
 use crate::{DeviceId, DistinctId, Map, system_snapshot::SystemSnapshotter};
 use crate::{Recorder, Worker};
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Builder {
     device_id: Option<DeviceId>,
     distinct_id: Option<DistinctId>,
@@ -39,46 +39,88 @@ impl Builder {
         }
     }
 
-    pub fn set_anonymous_distinct_id(
+    pub fn anonymous_distinct_id(
         mut self,
         anonymous_distinct_id: Option<AnonymousDistinctId>,
     ) -> Self {
+        self.set_anonymous_distinct_id(anonymous_distinct_id);
+        self
+    }
+
+    pub fn set_anonymous_distinct_id(
+        &mut self,
+        anonymous_distinct_id: Option<AnonymousDistinctId>,
+    ) -> &Self {
         self.anonymous_distinct_id = anonymous_distinct_id;
         self
     }
 
-    pub fn set_distinct_id(mut self, distinct_id: Option<DistinctId>) -> Self {
+    pub fn distinct_id(mut self, distinct_id: Option<DistinctId>) -> Self {
+        self.set_distinct_id(distinct_id);
+        self
+    }
+
+    pub fn set_distinct_id(&mut self, distinct_id: Option<DistinctId>) -> &Self {
         self.distinct_id = distinct_id;
         self
     }
 
-    pub fn set_device_id(mut self, device_id: Option<DeviceId>) -> Self {
+    pub fn device_id(mut self, device_id: Option<DeviceId>) -> Self {
+        self.set_device_id(device_id);
+        self
+    }
+
+    pub fn set_device_id(&mut self, device_id: Option<DeviceId>) -> &Self {
         self.device_id = device_id;
         self
     }
 
-    pub fn set_facts(mut self, facts: Option<Map>) -> Self {
+    pub fn facts(mut self, facts: Option<Map>) -> Self {
+        self.set_facts(facts);
+        self
+    }
+
+    pub fn set_facts(&mut self, facts: Option<Map>) -> &Self {
         self.facts = facts;
         self
     }
 
-    pub fn set_groups(mut self, groups: Option<Map>) -> Self {
+    pub fn groups(mut self, groups: Option<Map>) -> Self {
+        self.set_groups(groups);
+        self
+    }
+
+    pub fn set_groups(&mut self, groups: Option<Map>) -> &Self {
         self.groups = groups;
         self
     }
 
-    pub fn add_fact(
+    pub fn fact(
         mut self,
         key: impl Into<String> + std::fmt::Debug,
         value: impl Into<serde_json::Value>,
     ) -> Self {
+        self.set_fact(key, value);
+        self
+    }
+
+    pub fn set_fact(
+        &mut self,
+        key: impl Into<String> + std::fmt::Debug,
+        value: impl Into<serde_json::Value>,
+    ) -> &Self {
         self.facts
             .get_or_insert_with(Default::default)
             .insert(key.into(), value.into());
         self
     }
 
-    pub fn set_endpoint(mut self, endpoint: Option<String>) -> Self {
+    pub fn endpoint(mut self, endpoint: Option<String>) -> Self {
+        self.set_endpoint(endpoint);
+        self
+    }
+
+    pub fn set_endpoint(&mut self, endpoint: Option<String>) -> &Self {
         self.endpoint = endpoint;
         self
     }
@@ -104,22 +146,42 @@ impl Builder {
     ///   .await;
     /// # })
     /// ```
-    pub fn set_enable_reporting(mut self, enable_reporting: bool) -> Self {
+    pub fn enable_reporting(mut self, enable_reporting: bool) -> Self {
+        self.set_enable_reporting(enable_reporting);
+        self
+    }
+
+    pub fn set_enable_reporting(&mut self, enable_reporting: bool) -> &Self {
         self.enable_reporting = enable_reporting;
         self
     }
 
-    pub fn set_timeout(mut self, duration: Option<Duration>) -> Self {
+    pub fn timeout(mut self, duration: Option<Duration>) -> Self {
+        self.set_timeout(duration);
+        self
+    }
+
+    pub fn set_timeout(&mut self, duration: Option<Duration>) -> &Self {
         self.timeout = duration;
         self
     }
 
-    pub fn set_certificate(mut self, certificate: Option<Certificate>) -> Self {
+    pub fn certificate(mut self, certificate: Option<Certificate>) -> Self {
+        self.set_certificate(certificate);
+        self
+    }
+
+    pub fn set_certificate(&mut self, certificate: Option<Certificate>) -> &Self {
         self.certificate = certificate;
         self
     }
 
-    pub fn set_proxy(mut self, proxy: Option<Url>) -> Self {
+    pub fn proxy(mut self, proxy: Option<Url>) -> Self {
+        self.set_proxy(proxy);
+        self
+    }
+
+    pub fn set_proxy(&mut self, proxy: Option<Url>) -> &Self {
         self.proxy = proxy;
         self
     }

--- a/src/checkin.rs
+++ b/src/checkin.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use serde::Deserialize;
 
-use crate::{collator::FeatureFacts, Map};
+use crate::{Map, collator::FeatureFacts};
 
 pub(crate) type CoherentFeatureFlags = HashMap<String, Arc<Feature<serde_json::Value>>>;
 

--- a/src/collator.rs
+++ b/src/collator.rs
@@ -3,10 +3,10 @@ use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::oneshot::Sender as OneshotSender;
 use tracing::Instrument;
 
+use crate::Map;
 use crate::ds_correlation::Correlation;
 use crate::identity::{AnonymousDistinctId, DeviceId, DistinctId};
 use crate::recorder::RawSignal;
-use crate::Map;
 
 #[derive(serde::Serialize, Debug)]
 pub(crate) enum CollatedSignal {

--- a/src/configuration_proxy.rs
+++ b/src/configuration_proxy.rs
@@ -9,9 +9,9 @@ use tracing::Instrument;
 
 use crate::recorder::RawSignal;
 use crate::{
+    Map,
     checkin::{Checkin, Feature},
     collator::FeatureFacts,
-    Map,
 };
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub mod system_snapshot;
 pub mod transport;
 mod worker;
 
+#[cfg(feature = "nodejs")]
+mod nodejs;
+
 pub use builder::Builder;
 pub use identity::{AnonymousDistinctId, DeviceId, DistinctId};
 pub use recorder::Recorder;
@@ -28,4 +31,9 @@ macro_rules! builder {
             .add_fact("$app_version", env!("CARGO_PKG_VERSION"))
             .add_fact("$app_name", env!("CARGO_CRATE_NAME"))
     }};
+}
+
+#[cfg_attr(feature = "nodejs", neon::main)]
+fn neon_hook(cx: neon::prelude::ModuleContext) -> neon::result::NeonResult<()> {
+    crate::nodejs::neon_hook(cx)
 }

--- a/src/nodejs/builder.rs
+++ b/src/nodejs/builder.rs
@@ -1,0 +1,228 @@
+use std::sync::{Arc, Mutex};
+
+use neon::prelude::*;
+//use serde::Deserialize;
+
+use crate::Builder;
+
+use super::Error;
+
+pub(crate) fn neon_hook(cx: &mut ModuleContext) -> neon::result::NeonResult<()> {
+    cx.export_function("builderNew", Builder::js_new)?;
+    cx.export_function(
+        "builderSetAnonymousDistinctId",
+        Builder::js_set_anonymous_distinct_id,
+    )?;
+    cx.export_function(
+        "builderSetDistinctId",
+        Builder::js_set_distinct_id,
+    )?;
+    cx.export_function(
+        "builderSetDeviceId",
+        Builder::js_set_device_id,
+    )?;
+    cx.export_function(
+        "builderSetEndpoint",
+        Builder::js_set_endpoint,
+    )?;
+    cx.export_function(
+        "builderSetEnableReporting",
+        Builder::js_set_enable_reporting,
+    )?;
+    cx.export_function(
+        "builderSetTimeoutMs",
+        Builder::js_set_timeout_ms,
+    )?;
+    cx.export_function(
+        "builderSetFact",
+        Builder::js_set_fact,
+    )?;
+    cx.export_function(
+        "builderBuild",
+        Builder::js_build,
+    )?;
+
+    Ok(())
+}
+
+
+type JsBuilder = JsBox<Arc<Mutex<Builder>>>;
+
+impl Builder {
+    fn js_new(mut cx: FunctionContext) -> JsResult<JsBuilder> {
+        Ok(cx.boxed(Arc::new(Mutex::new(Builder::new()))))
+    }
+
+    fn js_set_anonymous_distinct_id(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_anonymous_distinct_id(v.map(crate::AnonymousDistinctId::from));
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_distinct_id(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_distinct_id(v.map(crate::DistinctId::from));
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_device_id(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_device_id(v.map(crate::DeviceId::from));
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_endpoint(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_endpoint(v);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_enable_reporting(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: bool = cx.argument::<JsBoolean>(1)?.value(&mut cx);
+
+        builder.set_enable_reporting(v);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_timeout_ms(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<std::time::Duration> = match cx.argument_opt(1) {
+            Some(v) => {
+                let millis_f64: f64 = v.downcast_or_throw::<JsNumber, _>(&mut cx)?.value(&mut cx);
+                let millis_i64 = millis_f64 as i32;
+                let millis: u64 = millis_i64
+                    .try_into()
+                    .map_err(Error::from)
+                    .or_else(|err| cx.throw_error(err.to_string()))?;
+
+                Some(std::time::Duration::from_millis(millis))
+            }
+            None => None,
+        };
+
+        builder.set_timeout(v);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_fact(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let key: String = cx.argument::<JsString>(1)?.value(&mut cx);
+        let value: String = cx.argument::<JsString>(2)?.value(&mut cx);
+
+        builder.set_fact(key, value);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_build(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let rt = super::runtime(&mut cx)?;
+
+        let binding = cx.this::<JsBuilder>()?;
+        let builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+            let bod = builder.clone().build_or_default();
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        rt.spawn(async move {
+            let (recorder, worker) = bod.await;
+            rt.spawn(worker.wait());
+
+            deferred.settle_with(&channel, move |mut cx| {
+                Ok(cx.boxed(recorder))
+            })
+        });
+
+        Ok(promise)
+    }
+}
+
+/*
+    pub fn set_certificate(mut self, certificate: Option<Certificate>) -> Self {
+        self.certificate = certificate;
+        self
+    }
+
+    pub fn set_proxy(mut self, proxy: Option<Url>) -> Self {
+        self.proxy = proxy;
+        self
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn build_or_default(mut self) -> (Recorder, Worker) {
+        let transport = self.transport_or_default().await;
+
+        self.build_with(
+            transport,
+            crate::system_snapshot::Generic::default(),
+            crate::storage::Generic::default(),
+        )
+        .await
+    }
+}
+ */

--- a/src/nodejs/mod.rs
+++ b/src/nodejs/mod.rs
@@ -1,0 +1,47 @@
+use std::sync::TryLockError;
+
+use neon::prelude::*;
+use once_cell::sync::OnceCell;
+//use serde::Deserialize;
+use tokio::runtime::Runtime;
+
+use crate::{Builder, Recorder};
+
+mod builder;
+mod recorder;
+
+// Lifted from the Neon example (licensed MIT):
+// https://github.com/neon-bindings/examples/blob/7a466b2c41bdee95bca51c0d3f65343f59436fbe/examples/tokio-fetch/src/lib.rs,
+//
+// Return a global tokio runtime or create one if it doesn't exist.
+// Throws a JavaScript exception if the `Runtime` fails to create.
+fn runtime<'a, C: Context<'a>>(cx: &mut C) -> NeonResult<&'static Runtime> {
+    static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+    RUNTIME.get_or_try_init(|| Runtime::new().or_else(|err| cx.throw_error(err.to_string())))
+}
+
+pub(crate) fn neon_hook(mut cx: ModuleContext) -> neon::result::NeonResult<()> {
+    builder::neon_hook(&mut cx)?;
+    recorder::neon_hook(&mut cx)?;
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug)]
+enum Error {
+    #[error("Could not lock the resource: {0}")]
+    Lock(String),
+
+    #[error("Invalid integer: {0}")]
+    FromInt(#[from] std::num::TryFromIntError),
+}
+
+impl<T> From<TryLockError<T>> for Error {
+    fn from(err: TryLockError<T>) -> Self {
+        Self::Lock(err.to_string())
+    }
+}
+
+impl Finalize for Builder {}
+impl Finalize for Recorder {}

--- a/src/nodejs/recorder.rs
+++ b/src/nodejs/recorder.rs
@@ -1,0 +1,282 @@
+use std::sync::{Arc, Mutex, TryLockError};
+
+use neon::prelude::*;
+//use serde::Deserialize;
+
+use crate::{Recorder};
+
+use super::Error;
+
+pub(crate) fn neon_hook(cx: &mut ModuleContext) -> neon::result::NeonResult<()> {
+    cx.export_function("recorderSetFact", Recorder::js_set_fact)?;
+
+    Ok(())
+}
+
+type JsRecorder = JsBox<Arc<Mutex<Recorder>>>;
+
+impl Recorder {
+    fn js_set_fact(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let binding = cx.this::<JsRecorder>()?;
+        let mut recorder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let key: String = cx.argument::<JsString>(1)?.value(&mut cx);
+        let value: String = cx.argument::<JsString>(2)?.value(&mut cx);
+
+
+        let t = recorder.add_fact(&key, serde_json::Value::String(value));
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        super::runtime(&mut cx)?.spawn(async move {
+            let r = t.await;
+
+            deferred.settle_with(&channel, move |mut cx| {
+                Ok(cx.undefined())
+            })
+        });
+
+        Ok(promise)
+    }
+}
+
+/*
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_variant<T: serde::de::DeserializeOwned + std::fmt::Debug + Send>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        serde_json::from_value(self.get_feature::<T>(key).await?.variant)
+            .inspect_err(|e| tracing::debug!(%e, "Deserializing feature variant failed"))
+            .ok()
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_ptr_variant<
+        T: serde::de::DeserializeOwned + Send + std::fmt::Debug,
+    >(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        serde_json::from_value(self.get_feature_ptr::<T>(key).await?.variant)
+            .inspect_err(|e| tracing::debug!(%e, "Deserializing feature variant failed"))
+            .ok()
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_payload<T: serde::de::DeserializeOwned + Send + std::fmt::Debug>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        self.get_feature::<T>(key).await?.payload
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_ptr_payload<
+        T: serde::de::DeserializeOwned + Send + std::fmt::Debug,
+    >(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        self.get_feature_ptr::<T>(key).await?.payload
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_ptr<T: serde::de::DeserializeOwned + Send + std::fmt::Debug>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<Feature<T>> {
+        let ptr = self.get_feature_payload::<String>(key).await?;
+        self.get_feature::<T>(ptr).await
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature<T: serde::de::DeserializeOwned + Send + std::fmt::Debug>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<Feature<T>> {
+        let key: String = key.into();
+        let (tx, rx) = oneshot();
+
+        self.to_configuration_proxy
+            .send(ConfigurationProxySignal::GetFeature(key.clone(), tx))
+            .instrument(tracing::trace_span!(
+                "requesting feature from the configuration proxy"
+            ))
+            .await
+            .inspect_err(|e| tracing::trace!(%e, "Error sending the feature flag request"))
+            .ok()?;
+
+        let feature = rx
+            .instrument(tracing::trace_span!("waiting for the feature"))
+            .await
+            .inspect_err(|e| tracing::trace!(%e, "Error requesting the feature flag"))
+            .ok()
+            .flatten()?;
+
+        self.record(
+            "$feature_flag_called",
+            Some(Map::from_iter([
+                ("$feature_flag".into(), key.into()),
+                ("$feature_flag_response".into(), feature.variant.clone()),
+            ])),
+        )
+        .await;
+
+        let variant = feature.variant.clone();
+        let payload = if let Some(ref p) = feature.payload {
+            let ret = serde_json::from_value(p.clone()).ok()?;
+            Some(ret)
+        } else {
+            None
+        };
+
+        Some(Feature { variant, payload })
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn record(&self, event: &str, properties: Option<Map>) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Event {
+                event_name: event.to_string(),
+                properties,
+            })
+            .instrument(tracing::trace_span!("recording the event"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue an event message");
+        }
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn identify(&self, new: DistinctId) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Identify(new))
+            .instrument(tracing::trace_span!("sending the Identify message"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue swap_identity message");
+        }
+
+        self.trigger_configuration_refresh()
+            .instrument(tracing::trace_span!("triggering a configuration refresh"))
+            .await;
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn alias(&self, alias: String) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Alias(alias))
+            .instrument(tracing::trace_span!("sending the Alias message"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue Alias message");
+        }
+
+        self.trigger_configuration_refresh()
+            .instrument(tracing::trace_span!("triggering a configuration refresh"))
+            .await;
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn reset(&self) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Reset)
+            .instrument(tracing::trace_span!("sending the Reset message"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue reset message");
+        }
+
+        self.trigger_configuration_refresh()
+            .instrument(tracing::trace_span!("triggering a configuration refresh"))
+            .await;
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self), ret(level = tracing::Level::TRACE)))]
+    async fn get_session_properties(&self) -> Result<Map, FullDuplexError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.outgoing
+            .send(RawSignal::GetSessionProperties { tx })
+            .instrument(tracing::trace_span!(
+                "sending the GetSessionProperties message"
+            ))
+            .await
+            .map_err(|_| FullDuplexError::SendError)?;
+
+        Ok(rx
+            .instrument(tracing::trace_span!("waiting for reply"))
+            .await?)
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn flush_now(&self) {
+        if let Err(e) = self.outgoing.send(RawSignal::FlushNow).await {
+            tracing::error!(error = ?e, "Failed to enqueue a FlushNow message");
+        }
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub(crate) async fn trigger_configuration_refresh(&self) {
+        let (tx, rx) = oneshot();
+
+        let session_properties = self
+            .get_session_properties()
+            .instrument(tracing::debug_span!("request session properties"))
+            .await
+            .inspect_err(|e| {
+                tracing::debug!(%e, "Failed to get session properties");
+            })
+            .unwrap_or_default();
+
+        if let Err(e) = self
+            .to_configuration_proxy
+            .send(ConfigurationProxySignal::CheckInNow(session_properties, tx))
+            .instrument(tracing::debug_span!("request immediate check-in"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue CheckInNow message");
+        }
+
+        let feats = match rx
+            .instrument(tracing::debug_span!("receive feature facts"))
+            .await
+        {
+            Ok(feats) => feats,
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to refresh the configuration");
+
+                return;
+            }
+        };
+
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::UpdateFeatureFacts(feats))
+            .instrument(tracing::debug_span!("forward feature facts"))
+            .await
+        {
+            tracing::error!(%e, "Failed to forward updated feature facts");
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FullDuplexError {
+    #[error("Failed to request session properties")]
+    SendError,
+
+    #[error("Error waiting for a reply: {0}")]
+    Recv(#[from] tokio::sync::oneshot::error::RecvError),
+}
+
+ */

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -2,11 +2,11 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot::channel as oneshot;
 use tracing::Instrument;
 
+use crate::Map;
 use crate::checkin::Feature;
 use crate::collator::FeatureFacts;
 use crate::configuration_proxy::ConfigurationProxySignal;
 use crate::identity::DistinctId;
-use crate::Map;
 
 #[derive(Debug)]
 pub(crate) enum RawSignal {

--- a/src/transport/file.rs
+++ b/src/transport/file.rs
@@ -5,8 +5,8 @@ use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufWriter};
 use tokio::sync::Mutex;
 
-use crate::submitter::Batch;
 use crate::Map;
+use crate::submitter::Batch;
 
 use super::Transport;
 

--- a/src/transport/file.rs
+++ b/src/transport/file.rs
@@ -54,7 +54,7 @@ impl Transport for FileTransport {
     type Error = FileTransportError;
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all))]
-    async fn submit<'b>(&mut self, batch: Batch<'b>) -> Result<(), Self::Error> {
+    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
         let mut handle = self.output_handle.lock().await;
 
         handle

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -41,7 +41,7 @@ impl Transport for ReqwestTransport {
     type Error = ReqwestTransportError;
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, ret(level = tracing::Level::TRACE)))]
-    async fn submit<'b>(&mut self, batch: Batch<'b>) -> Result<(), Self::Error> {
+    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
         let mut url = self.host.clone();
         url.set_path("/events/batch");
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -1,7 +1,7 @@
 use reqwest::Certificate;
 use url::Url;
 
-use crate::{submitter::Batch, Map};
+use crate::{Map, submitter::Batch};
 
 use super::Transport;
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -21,9 +21,9 @@ pub(crate) trait Transport: Send + Clone {
         session_properties: Map,
     ) -> impl Future<Output = Result<crate::checkin::Checkin, Self::Error>> + Send;
 
-    fn submit<'b>(
+    fn submit(
         &mut self,
-        batch: Batch<'b>,
+        batch: Batch<'_>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
@@ -118,7 +118,7 @@ impl Transport for Transports {
     }
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, ret(level = tracing::Level::TRACE)))]
-    async fn submit<'b>(&mut self, batch: Batch<'b>) -> Result<(), Self::Error> {
+    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
         match self {
             Self::None => Ok(()),
             Self::File(t) => Ok(t.submit(batch).await?),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -6,7 +6,7 @@ use reqwest::Certificate;
 use srv_http::SrvHttpTransport;
 use url::Url;
 
-use crate::{submitter::Batch, Map};
+use crate::{Map, submitter::Batch};
 
 mod file;
 mod http;
@@ -21,10 +21,7 @@ pub(crate) trait Transport: Send + Clone {
         session_properties: Map,
     ) -> impl Future<Output = Result<crate::checkin::Checkin, Self::Error>> + Send;
 
-    fn submit(
-        &mut self,
-        batch: Batch<'_>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn submit(&mut self, batch: Batch<'_>) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 pub(crate) fn default_transport_backend() -> (String, Url, Option<Vec<url::Host>>) {

--- a/src/transport/srv_http.rs
+++ b/src/transport/srv_http.rs
@@ -73,7 +73,7 @@ impl Transport for SrvHttpTransport {
     type Error = SrvHttpTransportError;
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, ret(level = tracing::Level::TRACE)))]
-    async fn submit<'b>(&mut self, batch: Batch<'b>) -> Result<(), Self::Error> {
+    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
         let payload = serde_json::to_string(&batch)?;
         let reqwest = self.reqwest.clone();
         let server_opts = self.server_options.clone();

--- a/src/transport/srv_http.rs
+++ b/src/transport/srv_http.rs
@@ -5,10 +5,10 @@ use reqwest::Certificate;
 use reqwest::Url;
 use tracing::Instrument;
 
+use crate::Map;
 use crate::checkin::Checkin;
 use crate::checkin::ServerOptions;
 use crate::submitter::Batch;
-use crate::Map;
 
 use super::Transport;
 


### PR DESCRIPTION
This was a bit of a lark of a project I started last night for fun, to see if we could replace a bunch of the hard work in detsys-ts with the much better Rust implementation here. This is especially relevant as we consider restructuring how we use `groups` to better support group analytics. Having to redo that in two or even three places (detsys-ids-client, detsys-ts, and ids) is a bummer.

Neon is a Rust<->NodeJS bridge, so you can build crates that exposes essentially an FFI to Node. Since detsys-ts is entirely used in GitHub Actions (node) it is feasible.

The interesting thing about Neon is it is TANTALIZINGLY approachable: creating the FFI interface is safe and easy and mostly a bit of ceremony about getting arguments and resolving  promises.

To compare with WASI/Wasm: is pretty hard, because it has to compile your entire dependency tree into a new target. A lot of crates support it, but not all of them. It is a much higher up front investment, and less _**tantalizingly approachable**_.

The problem with Neon is we'd have to build a static binary variant of the native library for each target (`{aarch64,x86_64}-{linux,darwin}`) and check that in to the GitHub Actions repositories that use it. This would make the repo size significantly larger :(.

Neon's downfall is the up-shot of WASI/Wasm: it is a single, architecture-neutral file that can execute on all of our targets that support Node ... which is all of them.

Anyway, this was a novel and -- again -- tantalizing -- experiment... but I think best left in the dustbin of closed draft PRs for now. I think some of the API improvements are good, though, and I'll probably pull those out.