### PR TITLE
What if: neon?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 Cargo.lock
 .direnv
+node_modules
+index.node
+package-lock.json

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ default = ["nodejs"]
 
 # See: https://github.com/tokio-rs/tracing/issues/3207
 tracing-instrument = []
-nodejs = ["neon"]
+nodejs = ["neon", "once_cell"]
 
 [lib]
 crate-type = ["lib", "cdylib"]
@@ -41,6 +41,7 @@ sys-locale = "0.3.2"
 iana-time-zone = "0.1.61"
 async-compression = { version = "0.4.18", features = ["zstd", "tokio"] }
 neon = { version = "1", features = [ "tokio" ], optional = true }
+once_cell = { version = "1.21.3", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,12 +4,14 @@ version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "A client for install.determinate.systems."
+exclude = ["index.node"]
 
 [features]
-default = []
+default = ["nodejs"]
 
 # See: https://github.com/tokio-rs/tracing/issues/3207
 tracing-instrument = []
+nodejs = ["neon"]
 
 [lib]
 crate-type = ["lib", "cdylib"]
@@ -38,6 +40,7 @@ is_ci = "1.2.0"
 sys-locale = "0.3.2"
 iana-time-zone = "0.1.61"
 async-compression = { version = "0.4.18", features = ["zstd", "tokio"] }
+neon = { version = "1", features = [ "tokio" ], optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ default = []
 # See: https://github.com/tokio-rs/tracing/issues/3207
 tracing-instrument = []
 
+[lib]
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/flake.nix
+++ b/flake.nix
@@ -76,6 +76,7 @@
               check.check-editorconfig
               check.check-clippy
               libiconv
+              nodePackages.npm
             ];
           };
         });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "detsys-ids-client",
+  "version": "0.4.3",
+  "description": "A client for install.determinate.systems.",
+  "main": "index.node",
+  "scripts": {
+    "build": "cargo-cp-artifact -nc index.node -- cargo build --message-format=json-render-diagnostics",
+    "install": "npm run build",
+    "test": "cargo test"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "cargo-cp-artifact": "^0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DeterminateSystems/detsys-ids-client.git"
+  },
+  "keywords": [],
+  "bugs": {
+    "url": "https://github.com/DeterminateSystems/detsys-ids-client/issues"
+  },
+  "homepage": "https://github.com/DeterminateSystems/detsys-ids-client#readme"
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ pub mod system_snapshot;
 pub mod transport;
 mod worker;
 
+#[cfg(feature = "nodejs")]
+mod nodejs;
+
 pub use builder::Builder;
 pub use identity::{AnonymousDistinctId, DeviceId, DistinctId};
 pub use recorder::Recorder;
@@ -28,4 +31,9 @@ macro_rules! builder {
             .add_fact("$app_version", env!("CARGO_PKG_VERSION"))
             .add_fact("$app_name", env!("CARGO_CRATE_NAME"))
     }};
+}
+
+#[cfg_attr(feature = "nodejs", neon::main)]
+fn neon_hook(cx: neon::prelude::ModuleContext) -> neon::result::NeonResult<()> {
+    crate::nodejs::neon_hook(cx)
 }

--- a/src/nodejs/builder.rs
+++ b/src/nodejs/builder.rs
@@ -1,0 +1,228 @@
+use std::sync::{Arc, Mutex};
+
+use neon::prelude::*;
+//use serde::Deserialize;
+
+use crate::Builder;
+
+use super::Error;
+
+pub(crate) fn neon_hook(cx: &mut ModuleContext) -> neon::result::NeonResult<()> {
+    cx.export_function("builderNew", Builder::js_new)?;
+    cx.export_function(
+        "builderSetAnonymousDistinctId",
+        Builder::js_set_anonymous_distinct_id,
+    )?;
+    cx.export_function(
+        "builderSetDistinctId",
+        Builder::js_set_distinct_id,
+    )?;
+    cx.export_function(
+        "builderSetDeviceId",
+        Builder::js_set_device_id,
+    )?;
+    cx.export_function(
+        "builderSetEndpoint",
+        Builder::js_set_endpoint,
+    )?;
+    cx.export_function(
+        "builderSetEnableReporting",
+        Builder::js_set_enable_reporting,
+    )?;
+    cx.export_function(
+        "builderSetTimeoutMs",
+        Builder::js_set_timeout_ms,
+    )?;
+    cx.export_function(
+        "builderSetFact",
+        Builder::js_set_fact,
+    )?;
+    cx.export_function(
+        "builderBuild",
+        Builder::js_build,
+    )?;
+
+    Ok(())
+}
+
+
+type JsBuilder = JsBox<Arc<Mutex<Builder>>>;
+
+impl Builder {
+    fn js_new(mut cx: FunctionContext) -> JsResult<JsBuilder> {
+        Ok(cx.boxed(Arc::new(Mutex::new(Builder::new()))))
+    }
+
+    fn js_set_anonymous_distinct_id(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_anonymous_distinct_id(v.map(crate::AnonymousDistinctId::from));
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_distinct_id(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_distinct_id(v.map(crate::DistinctId::from));
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_device_id(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_device_id(v.map(crate::DeviceId::from));
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_endpoint(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<String> = match cx.argument_opt(1) {
+            Some(v) => Some(v.downcast_or_throw::<JsString, _>(&mut cx)?.value(&mut cx)),
+            None => None,
+        };
+
+        builder.set_endpoint(v);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_enable_reporting(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: bool = cx.argument::<JsBoolean>(1)?.value(&mut cx);
+
+        builder.set_enable_reporting(v);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_timeout_ms(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let v: Option<std::time::Duration> = match cx.argument_opt(1) {
+            Some(v) => {
+                let millis_f64: f64 = v.downcast_or_throw::<JsNumber, _>(&mut cx)?.value(&mut cx);
+                let millis_i64 = millis_f64 as i32;
+                let millis: u64 = millis_i64
+                    .try_into()
+                    .map_err(Error::from)
+                    .or_else(|err| cx.throw_error(err.to_string()))?;
+
+                Some(std::time::Duration::from_millis(millis))
+            }
+            None => None,
+        };
+
+        builder.set_timeout(v);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_set_fact(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let binding = cx.this::<JsBuilder>()?;
+        let mut builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let key: String = cx.argument::<JsString>(1)?.value(&mut cx);
+        let value: String = cx.argument::<JsString>(2)?.value(&mut cx);
+
+        builder.set_fact(key, value);
+
+        Ok(cx.undefined())
+    }
+
+    fn js_build(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let rt = super::runtime(&mut cx)?;
+
+        let binding = cx.this::<JsBuilder>()?;
+        let builder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+            let bod = builder.clone().build_or_default();
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        rt.spawn(async move {
+            let (recorder, worker) = bod.await;
+            rt.spawn(worker.wait());
+
+            deferred.settle_with(&channel, move |mut cx| {
+                Ok(cx.boxed(recorder))
+            })
+        });
+
+        Ok(promise)
+    }
+}
+
+/*
+    pub fn set_certificate(mut self, certificate: Option<Certificate>) -> Self {
+        self.certificate = certificate;
+        self
+    }
+
+    pub fn set_proxy(mut self, proxy: Option<Url>) -> Self {
+        self.proxy = proxy;
+        self
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn build_or_default(mut self) -> (Recorder, Worker) {
+        let transport = self.transport_or_default().await;
+
+        self.build_with(
+            transport,
+            crate::system_snapshot::Generic::default(),
+            crate::storage::Generic::default(),
+        )
+        .await
+    }
+}
+ */

--- a/src/nodejs/mod.rs
+++ b/src/nodejs/mod.rs
@@ -1,0 +1,47 @@
+use std::sync::TryLockError;
+
+use neon::prelude::*;
+use once_cell::sync::OnceCell;
+//use serde::Deserialize;
+use tokio::runtime::Runtime;
+
+use crate::{Builder, Recorder};
+
+mod builder;
+mod recorder;
+
+// Lifted from the Neon example (licensed MIT):
+// https://github.com/neon-bindings/examples/blob/7a466b2c41bdee95bca51c0d3f65343f59436fbe/examples/tokio-fetch/src/lib.rs,
+//
+// Return a global tokio runtime or create one if it doesn't exist.
+// Throws a JavaScript exception if the `Runtime` fails to create.
+fn runtime<'a, C: Context<'a>>(cx: &mut C) -> NeonResult<&'static Runtime> {
+    static RUNTIME: OnceCell<Runtime> = OnceCell::new();
+
+    RUNTIME.get_or_try_init(|| Runtime::new().or_else(|err| cx.throw_error(err.to_string())))
+}
+
+pub(crate) fn neon_hook(mut cx: ModuleContext) -> neon::result::NeonResult<()> {
+    builder::neon_hook(&mut cx)?;
+    recorder::neon_hook(&mut cx)?;
+
+    Ok(())
+}
+
+#[derive(thiserror::Error, Debug)]
+enum Error {
+    #[error("Could not lock the resource: {0}")]
+    Lock(String),
+
+    #[error("Invalid integer: {0}")]
+    FromInt(#[from] std::num::TryFromIntError),
+}
+
+impl<T> From<TryLockError<T>> for Error {
+    fn from(err: TryLockError<T>) -> Self {
+        Self::Lock(err.to_string())
+    }
+}
+
+impl Finalize for Builder {}
+impl Finalize for Recorder {}

--- a/src/nodejs/recorder.rs
+++ b/src/nodejs/recorder.rs
@@ -1,0 +1,282 @@
+use std::sync::{Arc, Mutex, TryLockError};
+
+use neon::prelude::*;
+//use serde::Deserialize;
+
+use crate::{Recorder};
+
+use super::Error;
+
+pub(crate) fn neon_hook(cx: &mut ModuleContext) -> neon::result::NeonResult<()> {
+    cx.export_function("recorderSetFact", Recorder::js_set_fact)?;
+
+    Ok(())
+}
+
+type JsRecorder = JsBox<Arc<Mutex<Recorder>>>;
+
+impl Recorder {
+    fn js_set_fact(mut cx: FunctionContext) -> JsResult<JsPromise> {
+        let binding = cx.this::<JsRecorder>()?;
+        let mut recorder = binding
+            .try_lock()
+            .map_err(Error::from)
+            .or_else(|err| cx.throw_error(err.to_string()))?;
+
+        let key: String = cx.argument::<JsString>(1)?.value(&mut cx);
+        let value: String = cx.argument::<JsString>(2)?.value(&mut cx);
+
+
+        let t = recorder.add_fact(&key, serde_json::Value::String(value));
+        let channel = cx.channel();
+        let (deferred, promise) = cx.promise();
+
+        super::runtime(&mut cx)?.spawn(async move {
+            let r = t.await;
+
+            deferred.settle_with(&channel, move |mut cx| {
+                Ok(cx.undefined())
+            })
+        });
+
+        Ok(promise)
+    }
+}
+
+/*
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_variant<T: serde::de::DeserializeOwned + std::fmt::Debug + Send>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        serde_json::from_value(self.get_feature::<T>(key).await?.variant)
+            .inspect_err(|e| tracing::debug!(%e, "Deserializing feature variant failed"))
+            .ok()
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_ptr_variant<
+        T: serde::de::DeserializeOwned + Send + std::fmt::Debug,
+    >(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        serde_json::from_value(self.get_feature_ptr::<T>(key).await?.variant)
+            .inspect_err(|e| tracing::debug!(%e, "Deserializing feature variant failed"))
+            .ok()
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_payload<T: serde::de::DeserializeOwned + Send + std::fmt::Debug>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        self.get_feature::<T>(key).await?.payload
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_ptr_payload<
+        T: serde::de::DeserializeOwned + Send + std::fmt::Debug,
+    >(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<T> {
+        self.get_feature_ptr::<T>(key).await?.payload
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature_ptr<T: serde::de::DeserializeOwned + Send + std::fmt::Debug>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<Feature<T>> {
+        let ptr = self.get_feature_payload::<String>(key).await?;
+        self.get_feature::<T>(ptr).await
+    }
+
+    #[tracing::instrument(skip(self), ret(level = tracing::Level::TRACE))]
+    pub async fn get_feature<T: serde::de::DeserializeOwned + Send + std::fmt::Debug>(
+        &self,
+        key: impl Into<String> + std::fmt::Debug,
+    ) -> Option<Feature<T>> {
+        let key: String = key.into();
+        let (tx, rx) = oneshot();
+
+        self.to_configuration_proxy
+            .send(ConfigurationProxySignal::GetFeature(key.clone(), tx))
+            .instrument(tracing::trace_span!(
+                "requesting feature from the configuration proxy"
+            ))
+            .await
+            .inspect_err(|e| tracing::trace!(%e, "Error sending the feature flag request"))
+            .ok()?;
+
+        let feature = rx
+            .instrument(tracing::trace_span!("waiting for the feature"))
+            .await
+            .inspect_err(|e| tracing::trace!(%e, "Error requesting the feature flag"))
+            .ok()
+            .flatten()?;
+
+        self.record(
+            "$feature_flag_called",
+            Some(Map::from_iter([
+                ("$feature_flag".into(), key.into()),
+                ("$feature_flag_response".into(), feature.variant.clone()),
+            ])),
+        )
+        .await;
+
+        let variant = feature.variant.clone();
+        let payload = if let Some(ref p) = feature.payload {
+            let ret = serde_json::from_value(p.clone()).ok()?;
+            Some(ret)
+        } else {
+            None
+        };
+
+        Some(Feature { variant, payload })
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn record(&self, event: &str, properties: Option<Map>) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Event {
+                event_name: event.to_string(),
+                properties,
+            })
+            .instrument(tracing::trace_span!("recording the event"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue an event message");
+        }
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn identify(&self, new: DistinctId) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Identify(new))
+            .instrument(tracing::trace_span!("sending the Identify message"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue swap_identity message");
+        }
+
+        self.trigger_configuration_refresh()
+            .instrument(tracing::trace_span!("triggering a configuration refresh"))
+            .await;
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn alias(&self, alias: String) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Alias(alias))
+            .instrument(tracing::trace_span!("sending the Alias message"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue Alias message");
+        }
+
+        self.trigger_configuration_refresh()
+            .instrument(tracing::trace_span!("triggering a configuration refresh"))
+            .await;
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn reset(&self) {
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::Reset)
+            .instrument(tracing::trace_span!("sending the Reset message"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue reset message");
+        }
+
+        self.trigger_configuration_refresh()
+            .instrument(tracing::trace_span!("triggering a configuration refresh"))
+            .await;
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self), ret(level = tracing::Level::TRACE)))]
+    async fn get_session_properties(&self) -> Result<Map, FullDuplexError> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        self.outgoing
+            .send(RawSignal::GetSessionProperties { tx })
+            .instrument(tracing::trace_span!(
+                "sending the GetSessionProperties message"
+            ))
+            .await
+            .map_err(|_| FullDuplexError::SendError)?;
+
+        Ok(rx
+            .instrument(tracing::trace_span!("waiting for reply"))
+            .await?)
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub async fn flush_now(&self) {
+        if let Err(e) = self.outgoing.send(RawSignal::FlushNow).await {
+            tracing::error!(error = ?e, "Failed to enqueue a FlushNow message");
+        }
+    }
+
+    #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip(self)))]
+    pub(crate) async fn trigger_configuration_refresh(&self) {
+        let (tx, rx) = oneshot();
+
+        let session_properties = self
+            .get_session_properties()
+            .instrument(tracing::debug_span!("request session properties"))
+            .await
+            .inspect_err(|e| {
+                tracing::debug!(%e, "Failed to get session properties");
+            })
+            .unwrap_or_default();
+
+        if let Err(e) = self
+            .to_configuration_proxy
+            .send(ConfigurationProxySignal::CheckInNow(session_properties, tx))
+            .instrument(tracing::debug_span!("request immediate check-in"))
+            .await
+        {
+            tracing::error!(error = ?e, "Failed to enqueue CheckInNow message");
+        }
+
+        let feats = match rx
+            .instrument(tracing::debug_span!("receive feature facts"))
+            .await
+        {
+            Ok(feats) => feats,
+            Err(e) => {
+                tracing::error!(error = ?e, "Failed to refresh the configuration");
+
+                return;
+            }
+        };
+
+        if let Err(e) = self
+            .outgoing
+            .send(RawSignal::UpdateFeatureFacts(feats))
+            .instrument(tracing::debug_span!("forward feature facts"))
+            .await
+        {
+            tracing::error!(%e, "Failed to forward updated feature facts");
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FullDuplexError {
+    #[error("Failed to request session properties")]
+    SendError,
+
+    #[error("Error waiting for a reply: {0}")]
+    Recv(#[from] tokio::sync::oneshot::error::RecvError),
+}
+
+ */


### PR DESCRIPTION
This was a bit of a lark of a project I started last night for fun, to see if we could replace a bunch of the hard work in detsys-ts with the much better Rust implementation here. This is especially relevant as we consider restructuring how we use `groups` to better support group analytics. Having to redo that in two or even three places (detsys-ids-client, detsys-ts, and ids) is a bummer.

Neon is a Rust<->NodeJS bridge, so you can build crates that exposes essentially an FFI to Node. Since detsys-ts is entirely used in GitHub Actions (node) it is feasible.

The interesting thing about Neon is it is TANTALIZINGLY approachable: creating the FFI interface is safe and easy and mostly a bit of ceremony about getting arguments and resolving  promises.

To compare with WASI/Wasm: is pretty hard, because it has to compile your entire dependency tree into a new target. A lot of crates support it, but not all of them. It is a much higher up front investment, and less _**tantalizingly approachable**_.

The problem with Neon is we'd have to build a static binary variant of the native library for each target (`{aarch64,x86_64}-{linux,darwin}`) and check that in to the GitHub Actions repositories that use it. This would make the repo size significantly larger :(.

Neon's downfall is the up-shot of WASI/Wasm: it is a single, architecture-neutral file that can execute on all of our targets that support Node ... which is all of them.

Anyway, this was a novel and -- again -- tantalizing -- experiment... but I think best left in the dustbin of closed draft PRs for now. I think some of the API improvements are good, though, and I'll probably pull those out.