### PR TITLE
Grahamc/make detsys ts correlation more specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Check Clippy
         if: always()
         run: nix develop --command check-clippy
+      - name: Run tests
+        if: always()
+        run: nix develop --command cargo test
 
   DeterminateCI:
     needs:

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -137,7 +137,7 @@ impl Builder {
     /// let cli = Cli { no_telemetry: false, };
     ///
     /// let (recorder, worker) = builder!()
-    ///   .set_enable_reporting(!cli.no_telemetry)
+    ///   .enable_reporting(!cli.no_telemetry)
     ///   .build_or_default()
     ///   .await;
     /// # })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,8 @@ pub type Map = serde_json::Map<String, serde_json::Value>;
 macro_rules! builder {
     () => {{
         detsys_ids_client::Builder::new()
-            .add_fact("cargo_pkg_name", env!("CARGO_PKG_NAME"))
-            .add_fact("$app_version", env!("CARGO_PKG_VERSION"))
-            .add_fact("$app_name", env!("CARGO_CRATE_NAME"))
+            .fact("cargo_pkg_name", env!("CARGO_PKG_NAME"))
+            .fact("$app_version", env!("CARGO_PKG_VERSION"))
+            .fact("$app_name", env!("CARGO_CRATE_NAME"))
     }};
 }


### PR DESCRIPTION
We're getting away from that style of serialization, but the DetsysTs variant requires essentially nothing.
That means EVERYTHING deserializes into that code path and nothing into the Direct format.

DetsysTS always writes out the repository field, so that makes it work.

Another workaround is for DetsysTs to write out the `run` field as a list, which forces moving to the Direct parse.
