### PR TITLE
Make it possible to override the transport at runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "detsys-ids-client"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "A client for install.determinate.systems."
@@ -39,6 +39,7 @@ url = "2.5.4"
 uuid = { version = "1.12.1", features = [ "v4", "v7", "serde"] }
 xdg = "3.0.0"
 rustls = { version = "0.23.37", features = ["aws-lc-rs"] }
+arc-swap = "1.9"
 
 [dev-dependencies]
 once_cell = "1.21.3"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::identity::AnonymousDistinctId;
 use crate::storage::Storage;
-use crate::transport::{Transport, TransportsError};
+use crate::transport::{Transport, Transports, TransportsError};
 use crate::{DeviceId, DistinctId, Map, system_snapshot::SystemSnapshotter};
 use crate::{Groups, Recorder, Worker};
 
@@ -183,7 +183,7 @@ impl Builder {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn try_build(mut self) -> Result<(Recorder, Worker), TransportsError> {
+    pub async fn try_build(mut self) -> Result<(Recorder<Transports>, Worker), TransportsError> {
         let transport = self.transport().await?;
 
         Ok(self
@@ -196,7 +196,7 @@ impl Builder {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn build_or_default(mut self) -> (Recorder, Worker) {
+    pub async fn build_or_default(mut self) -> (Recorder<Transports>, Worker) {
         let transport = self.transport_or_default().await;
 
         self.build_with(
@@ -212,7 +212,7 @@ impl Builder {
         mut self,
         snapshotter: S,
         storage: P,
-    ) -> Result<(Recorder, Worker), TransportsError> {
+    ) -> Result<(Recorder<Transports>, Worker), TransportsError> {
         let transport = self.transport().await?;
 
         Ok(self.build_with(transport, snapshotter, storage).await)
@@ -223,7 +223,7 @@ impl Builder {
         mut self,
         snapshotter: S,
         storage: P,
-    ) -> (Recorder, Worker) {
+    ) -> (Recorder<Transports>, Worker) {
         let transport = self.transport_or_default().await;
 
         self.build_with(transport, snapshotter, storage).await
@@ -235,7 +235,7 @@ impl Builder {
         transport: T,
         snapshotter: S,
         storage: P,
-    ) -> (Recorder, Worker) {
+    ) -> (Recorder<T>, Worker) {
         Worker::new(
             self.anonymous_distinct_id.take(),
             self.distinct_id.take(),

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -6,6 +6,7 @@ use crate::checkin::{Checkin, Feature};
 use crate::collator::FeatureFacts;
 use crate::configuration_proxy::{CheckinStatus, ConfigurationProxySignal};
 use crate::identity::DistinctId;
+use crate::transport::Transport;
 use crate::{Map, PersonProperties};
 
 #[derive(Debug)]
@@ -82,15 +83,17 @@ pub enum RecorderError {
     Response(#[from] tokio::sync::oneshot::error::RecvError),
 }
 
-pub struct Recorder {
+pub struct Recorder<T: Transport> {
+    pub transport: T,
     outgoing: Sender<RawSignal>,
     auto_refresh_config: bool,
     to_configuration_proxy: Sender<ConfigurationProxySignal>,
 }
 
-impl Clone for Recorder {
+impl<T: Transport> Clone for Recorder<T> {
     fn clone(&self) -> Self {
         Self {
+            transport: self.transport.clone(),
             outgoing: self.outgoing.clone(),
             auto_refresh_config: true,
             to_configuration_proxy: self.to_configuration_proxy.clone(),
@@ -98,19 +101,21 @@ impl Clone for Recorder {
     }
 }
 
-impl std::fmt::Debug for Recorder {
+impl<T: Transport> std::fmt::Debug for Recorder<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Recorder").finish()
     }
 }
 
-impl Recorder {
+impl<Tr: Transport> Recorder<Tr> {
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all))]
     pub(crate) fn new(
+        transport: Tr,
         snapshotter_tx: Sender<RawSignal>,
         to_configuration_proxy: Sender<ConfigurationProxySignal>,
     ) -> Self {
         Self {
+            transport,
             outgoing: snapshotter_tx,
             to_configuration_proxy,
             auto_refresh_config: true,
@@ -121,7 +126,7 @@ impl Recorder {
     // Note: there are no atomic semantics, and configuration is refreshed at the end no matter what your function does.
     pub async fn in_configuration_txn<F, T>(&self, f: F) -> T
     where
-        F: AsyncFnOnce(&Recorder) -> T,
+        F: AsyncFnOnce(&Recorder<Tr>) -> T,
     {
         let mut rec = self.clone();
 

--- a/src/submitter.rs
+++ b/src/submitter.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc::Receiver;
 use crate::collator::{CollatedSignal, Event};
 
 #[derive(Debug, serde::Serialize)]
-pub(crate) struct Batch<'a> {
+pub struct Batch<'a> {
     sent_at: String,
     batch: &'a [Event],
 }

--- a/src/test/slow_transport.rs
+++ b/src/test/slow_transport.rs
@@ -42,7 +42,7 @@ impl Transport for SlowTransport {
             .ok_or(Error::Simulated)
     }
 
-    async fn submit(&mut self, _batch: crate::submitter::Batch<'_>) -> Result<(), Self::Error> {
+    async fn submit(&self, _batch: crate::submitter::Batch<'_>) -> Result<(), Self::Error> {
         tokio::time::sleep(self.duration).await;
         Err(Error::Simulated)
     }

--- a/src/transport/file.rs
+++ b/src/transport/file.rs
@@ -11,7 +11,7 @@ use crate::submitter::Batch;
 use super::Transport;
 
 #[derive(Clone)]
-pub(crate) struct FileTransport {
+pub struct FileTransport {
     checkin: Option<(PathBuf, Arc<Mutex<File>>)>,
 
     output_path: PathBuf,
@@ -54,7 +54,7 @@ impl Transport for FileTransport {
     type Error = FileTransportError;
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all))]
-    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
+    async fn submit(&self, batch: Batch<'_>) -> Result<(), Self::Error> {
         let mut handle = self.output_handle.lock().await;
 
         handle

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -6,7 +6,7 @@ use crate::{Map, submitter::Batch};
 use super::Transport;
 
 #[derive(Clone)]
-pub(crate) struct ReqwestTransport {
+pub struct ReqwestTransport {
     host: Url,
     timeout: std::time::Duration,
     client: reqwest::Client,
@@ -41,7 +41,7 @@ impl Transport for ReqwestTransport {
     type Error = ReqwestTransportError;
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, ret(level = tracing::Level::TRACE)))]
-    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
+    async fn submit(&self, batch: Batch<'_>) -> Result<(), Self::Error> {
         let mut url = self.host.clone();
         url.set_path("/events/batch");
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,5 +1,6 @@
-use std::{future::Future, time::Duration};
+use std::{future::Future, sync::Arc, time::Duration};
 
+use arc_swap::ArcSwap;
 use file::FileTransport;
 use http::ReqwestTransport;
 use reqwest::Certificate;
@@ -18,7 +19,7 @@ const IDS_HOST: &str = "install.determinate.systems";
 const IDS_HOST: &str = "install.determinate.us";
 pub(crate) const APPLICATION_JSON: &str = "application/json";
 
-pub(crate) trait Transport: Send + Sync + Clone + 'static {
+pub trait Transport: Send + Sync + Clone + 'static {
     type Error: std::error::Error;
 
     fn checkin(
@@ -26,7 +27,7 @@ pub(crate) trait Transport: Send + Sync + Clone + 'static {
         session_properties: Map,
     ) -> impl Future<Output = Result<crate::checkin::Checkin, Self::Error>> + Send;
 
-    fn submit(&mut self, batch: Batch<'_>) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn submit(&self, batch: Batch<'_>) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }
 
 pub(crate) fn default_transport_backend() -> (String, Url, Option<Vec<url::Host>>) {
@@ -42,7 +43,12 @@ pub(crate) fn default_transport_backend() -> (String, Url, Option<Vec<url::Host>
 }
 
 #[derive(Clone)]
-pub(crate) enum Transports {
+pub struct Transports {
+    pub transport_kind: Arc<ArcSwap<TransportKind>>,
+}
+
+#[derive(Clone)]
+pub enum TransportKind {
     None,
     File(FileTransport),
     Http(ReqwestTransport),
@@ -51,53 +57,64 @@ pub(crate) enum Transports {
 
 impl Transports {
     pub(crate) fn none() -> Self {
-        Transports::None
+        Self {
+            transport_kind: Arc::new(ArcSwap::from_pointee(TransportKind::None)),
+        }
     }
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(err(level = tracing::Level::TRACE)))]
     pub(crate) async fn try_new(
-        opt_value: Option<String>,
+        transport_url: Option<String>,
         timeout: Duration,
         certificates: Option<Certificate>,
         proxy: Option<Url>,
     ) -> Result<Self, TransportsError> {
-        let Some(value) = opt_value else {
-            let (record, fallback, allowed_suffixes) = default_transport_backend();
+        let transport_kind = match transport_url {
+            Some(transport_url) => {
+                let url = Url::parse(&transport_url).or_else(|e| {
+                    if e == url::ParseError::RelativeUrlWithoutBase {
+                        tracing::debug!("Re-parsing the URL with a file:// prefix");
+                        Url::parse(&format!("file://{transport_url}"))
+                    } else {
+                        Err(e)
+                    }
+                })?;
 
-            return Ok(Self::SrvHttp(SrvHttpTransport::new(
-                record,
-                fallback,
-                allowed_suffixes,
-                timeout,
-                certificates,
-                proxy,
-            )?));
-        };
-        let url = Url::parse(&value).or_else(|e| {
-            if e == url::ParseError::RelativeUrlWithoutBase {
-                tracing::debug!("Re-parsing the URL with a file:// prefix");
-                Url::parse(&format!("file://{value}"))
-            } else {
-                Err(e)
+                match url.scheme() {
+                    "https" | "http" => TransportKind::Http(http::ReqwestTransport::new(
+                        url,
+                        timeout,
+                        certificates,
+                        proxy,
+                    )?),
+                    "file" => TransportKind::File(
+                        FileTransport::new(
+                            url.path(),
+                            std::env::var_os("DETSYS_IDS_CHECKIN_FILE")
+                                .map(std::path::PathBuf::from),
+                        )
+                        .await?,
+                    ),
+                    _ => return Err(TransportsError::UnknownUrlScheme),
+                }
             }
-        })?;
+            None => {
+                let (record, fallback, allowed_suffixes) = default_transport_backend();
 
-        match url.scheme() {
-            "https" | "http" => Ok(Transports::Http(http::ReqwestTransport::new(
-                url,
-                timeout,
-                certificates,
-                proxy,
-            )?)),
-            "file" => Ok(Transports::File(
-                FileTransport::new(
-                    url.path(),
-                    std::env::var_os("DETSYS_IDS_CHECKIN_FILE").map(std::path::PathBuf::from),
-                )
-                .await?,
-            )),
-            _ => Err(TransportsError::UnknownUrlScheme),
-        }
+                TransportKind::SrvHttp(SrvHttpTransport::new(
+                    record,
+                    fallback,
+                    allowed_suffixes,
+                    timeout,
+                    certificates,
+                    proxy,
+                )?)
+            }
+        };
+
+        Ok(Self {
+            transport_kind: Arc::new(ArcSwap::from_pointee(transport_kind)),
+        })
     }
 }
 
@@ -109,24 +126,23 @@ impl Transport for Transports {
         &self,
         session_properties: Map,
     ) -> Result<crate::checkin::Checkin, Self::Error> {
-        match self {
-            Self::None => Ok(crate::checkin::Checkin {
-                options: std::collections::HashMap::new(),
+        match self.transport_kind.load().as_ref() {
+            TransportKind::None => Ok(crate::checkin::Checkin {
                 ..Default::default()
             }),
-            Self::File(t) => Ok(t.checkin(session_properties).await?),
-            Self::Http(t) => Ok(t.checkin(session_properties).await?),
-            Self::SrvHttp(t) => Ok(t.checkin(session_properties).await?),
+            TransportKind::File(t) => Ok(t.checkin(session_properties).await?),
+            TransportKind::Http(t) => Ok(t.checkin(session_properties).await?),
+            TransportKind::SrvHttp(t) => Ok(t.checkin(session_properties).await?),
         }
     }
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, ret(level = tracing::Level::TRACE)))]
-    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
-        match self {
-            Self::None => Ok(()),
-            Self::File(t) => Ok(t.submit(batch).await?),
-            Self::Http(t) => Ok(t.submit(batch).await?),
-            Self::SrvHttp(t) => Ok(t.submit(batch).await?),
+    async fn submit(&self, batch: Batch<'_>) -> Result<(), Self::Error> {
+        match self.transport_kind.load().as_ref() {
+            TransportKind::None => Ok(()),
+            TransportKind::File(t) => Ok(t.submit(batch).await?),
+            TransportKind::Http(t) => Ok(t.submit(batch).await?),
+            TransportKind::SrvHttp(t) => Ok(t.submit(batch).await?),
         }
     }
 }

--- a/src/transport/srv_http.rs
+++ b/src/transport/srv_http.rs
@@ -20,7 +20,7 @@ type Resolver = hickory_resolver::TokioResolver;
 // >;
 
 #[derive(Clone)]
-pub(crate) struct SrvHttpTransport {
+pub struct SrvHttpTransport {
     srv: Arc<SrvClient<Resolver>>,
     server_options: Arc<tokio::sync::RwLock<crate::checkin::ServerOptions>>,
     reqwest: reqwest::Client,
@@ -75,7 +75,7 @@ impl Transport for SrvHttpTransport {
     type Error = SrvHttpTransportError;
 
     #[cfg_attr(feature = "tracing-instrument", tracing::instrument(skip_all, ret(level = tracing::Level::TRACE)))]
-    async fn submit(&mut self, batch: Batch<'_>) -> Result<(), Self::Error> {
+    async fn submit(&self, batch: Batch<'_>) -> Result<(), Self::Error> {
         let payload = serde_json::to_string(&batch)?;
         let reqwest = self.reqwest.clone();
         let server_opts = self.server_options.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -42,7 +42,7 @@ impl Worker {
         system_snapshotter: F,
         storage: P,
         transport: T,
-    ) -> (Recorder, Worker) {
+    ) -> (Recorder<T>, Worker) {
         // Message flow:
         //
         // Recorder --> Configuration --\
@@ -52,7 +52,11 @@ impl Worker {
         let (to_collator, collator_rx) = channel(1000);
         let (to_submitter, submitter_rx) = channel(1000);
 
-        let recorder = Recorder::new(to_collator.clone(), to_configuration_proxy);
+        let recorder = Recorder::new(
+            transport.clone(),
+            to_collator.clone(),
+            to_configuration_proxy,
+        );
         let mut configuration =
             ConfigurationProxy::new(transport.clone(), configuration_proxy_rx, to_collator);
         let collator = Collator::new(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable, public transport support (file, HTTP, and service-based HTTP) with runtime transport selection.
  - Exposed transport components and batch submission types for easier integration.

- **Improvements**
  - Event submissions now work without exclusive mutable access across transports.
  - Builder/worker APIs now return a transport-specific recorder.

- **Release**
  - Updated the crate version to **0.8.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->